### PR TITLE
Changed to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The API is mostly equivalent with the JavaScript client:
 
 ```ruby
 client = MessageBus::Client.new('http://chat.samsaffron.com/')
-subject.subscribe('/message') do |payload|
+client.subscribe('/message') do |payload|
   # Do stuff
 end
 


### PR DESCRIPTION
Looks like it came from rspec test `subject.subscribe('/message') do |payload|`

https://github.com/lowjoel/message_bus-client/blob/c74ac368ad109c36eb6ed1a04bf0beb23cdd80e0/spec/message_bus/client_spec.rb
